### PR TITLE
Get latest release URL from Jetbrains

### DIFF
--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -4,15 +4,16 @@
 echo -e " \e[94mInstalling Jetbrains Toolbox\e[39m"
 echo ""
 
-FILE=$(basename ${URL})
-DEST=$PWD/$FILE
-
 function getLatestUrl() {
 USER_AGENT=('User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36')
 
-URL=$(curl 'https://data.services.jetbrains.com//products/releases?code=TBA&latest=true&type=release' -H 'Origin: https://www.jetbrains.com' -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-US,en;q=0.8' -H "${USER_AGENT[@]}" -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Referer: https://www.jetbrains.com/toolbox/download/' -H 'Connection: keep-alive' -H 'DNT: 1' --compressed | grep -Po '"linux":.*?[^\\]",' | awk -F ':' '{print $3,$4}' | sed 's/[",]//g')
+URL=$(curl 'https://data.services.jetbrains.com//products/releases?code=TBA&latest=true&type=release' -H 'Origin: https://www.jetbrains.com' -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-US,en;q=0.8' -H "${USER_AGENT[@]}" -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Referer: https://www.jetbrains.com/toolbox/download/' -H 'Connection: keep-alive' -H 'DNT: 1' --compressed | grep -Po '"linux":.*?[^\\]",' | awk -F ':' '{print $3,":"$4}'| sed 's/[", ]//g')
+echo $URL
 }
 getLatestUrl
+
+FILE=$(basename ${URL})
+DEST=$PWD/$FILE
 
 echo ""
 echo -e "\e[94mDownloading Toolbox files \e[39m"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -4,11 +4,16 @@
 echo -e " \e[94mInstalling Jetbrains Toolbox\e[39m"
 echo ""
 
-URL="https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.0.2095.tar.gz"
-
 FILE=$(basename ${URL})
-
 DEST=$PWD/$FILE
+
+function getLatestUrl() {
+USER_AGENT=('User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36')
+
+URL=$(curl 'https://data.services.jetbrains.com//products/releases?code=TBA&latest=true&type=release' -H 'Origin: https://www.jetbrains.com' -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-US,en;q=0.8' -H "${USER_AGENT[@]}" -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Referer: https://www.jetbrains.com/toolbox/download/' -H 'Connection: keep-alive' -H 'DNT: 1' --compressed | grep -Po '"linux":.*?[^\\]",' | awk -F ':' '{print $3,$4}' | sed 's/[",]//g')
+}
+getLatestUrl
+
 echo ""
 echo -e "\e[94mDownloading Toolbox files \e[39m"
 echo ""


### PR DESCRIPTION
The script is awesome, but I removed the hardcoded URL for the download and now it fetches the latest version from Jetbrains and provides it to the URL var.