### PR TITLE
Make a cURL install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ This installer automates the following steps:
 
 ## Usage
 
-Run the following command to get started with Toolbox. This command requires that you have `sudo` privileges.
-
+Run the following command to get started with Toolbox. This command requires that you have `sudo` privileges and `curl`.  
 `curl -fsSL https://raw.githubusercontent.com/nagygergo/jetbrains-toolbox-install/master/jetbrains-toolbox.sh | bash`
+
+Alternatively, you can download the `jetbrains-toolbox.sh` file on this repository. It will still require `sudo` privileges to install.
 
 Afterwards you may execute the `jetbrains-toolbox` binary to run the Toolbox App and select which product and version you want to install.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This installer automates the following steps:
 
 ## Usage
 
-Download `jetbrains-toolbox.sh` and run it. It requires sudo rigths to execute.
+Run the following command to get started with Toolbox. This command requires that you have `sudo` privileges.
+
+`curl -fsSL https://raw.githubusercontent.com/nagygergo/jetbrains-toolbox-install/master/jetbrains-toolbox.sh | bash`
 
 Afterwards you may execute the `jetbrains-toolbox` binary to run the Toolbox App and select which product and version you want to install.
 


### PR DESCRIPTION
Made a one-line command to skip downloading and manually launching the script and instead download the raw file with cURL and execute it with `bash`. This obviously streamlines thing a bit, judging by how most modern Linux distributions come with cURL installed, and is a preferred method to install scripts (similar to Homebrew's install.sh) as it only requires one step.
I also added a note saying that the old way works too.