### PR TITLE
Allow passing script arguments to toolbox binary

### DIFF
--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -32,8 +32,8 @@ fi
 
 chmod -R +rwx ${DIR}
 touch ${DIR}/jetbrains-toolbox.sh
-echo "#!/bin/bash" >> $DIR/jetbrains-toolbox.sh
-echo "$DIR/jetbrains-toolbox" >> $DIR/jetbrains-toolbox.sh
+echo '#!/bin/bash' >> $DIR/jetbrains-toolbox.sh
+echo "$DIR/jetbrains-toolbox \$@" >> $DIR/jetbrains-toolbox.sh
 
 ln -s ${DIR}/jetbrains-toolbox.sh /usr/local/bin/jetbrains-toolbox
 chmod -R +rwx /usr/local/bin/jetbrains-toolbox


### PR DESCRIPTION
Hey folks,

Thanks for the great script, it really makes it far easier to automate the jetbrains toolbox install :) I've noticed an issue and put up this MR, let me know if I should make any changes!

The current version of the script does not allow commands such as `jetbrains-toolbox --version` to execute correctly, because the arguments to the symlink script are not passed to the binary. This commit fixes that by ensuring the arguments are passed as expected.

Existing users who want the functionality enabled will either have to rerun the download script, or manually replicate this change in their symlinked script.