### PR TITLE
Fixes #14

### DIFF
--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -26,7 +26,7 @@ DIR="/opt/jetbrains-toolbox"
 echo ""
 echo  -e "\e[94mInstalling to $DIR\e[39m"
 echo ""
-if mkdir ${DIR}; then
+if mkdir -p ${DIR}; then
     tar -xzf ${DEST} -C ${DIR} --strip-components=1
 fi
 


### PR DESCRIPTION
Uses `mkdir -p` to create the /opt directory if it doesn't exists.