### PR TITLE
Refactor install script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Run install
-        run: sudo $GITHUB_WORKSPACE/jetbrains-toolbox.sh
+        run: $GITHUB_WORKSPACE/jetbrains-toolbox.sh
       
       - name: Validate that symlink has been created
-        run:  "[ -f /usr/local/bin/jetbrains-toolbox ]"
+        run:  "[ -f $HOME/.local/bin/jetbrains-toolbox ]"
 
       - name: Validate command can be called
-        run: jetbrains-toolbox
+        run: $HOME/.local/share/JetBrains/Toolbox/bin/jetbrains-toolbox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         run: $GITHUB_WORKSPACE/jetbrains-toolbox.sh
       
       - name: Validate that symlink has been created
-        run:  "[ -f $HOME/.local/bin/jetbrains-toolbox ]"
+        run:  '[ -f $HOME/.local/bin/jetbrains-toolbox ]'
 
-      - name: Validate command can be called
-        run: $HOME/.local/share/JetBrains/Toolbox/bin/jetbrains-toolbox
+      - name: Validate command is executable
+        run: '[[ $(file "$HOME/.local/share/JetBrains/Toolbox/bin/jetbrains-toolbox") == *"ELF 64-bit LSB executable"* ]]'

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -23,7 +23,7 @@ chmod +x "$INSTALL_DIR/jetbrains-toolbox"
 
 echo -e "\e[94mSymlinking to $SYMLINK_DIR/jetbrains-toolbox...\e[39m"
 mkdir -p $SYMLINK_DIR
-rm "$SYMLINK_DIR/jetbrains-toolbox"
+rm "$SYMLINK_DIR/jetbrains-toolbox" || true
 ln -s "$INSTALL_DIR/jetbrains-toolbox" "$SYMLINK_DIR/jetbrains-toolbox"
 
 echo  -e "\e[94mRunning for the first time to set-up...\e[39m"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -13,10 +13,12 @@ ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?cod
 ARCHIVE_FILENAME=$(basename "$ARCHIVE_URL")
 
 echo -e "\e[94mDownloading $ARCHIVE_FILENAME...\e[39m"
+rm "$TMP_DIR/$ARCHIVE_FILENAME" || true
 wget -q --show-progress -cO "$TMP_DIR/$ARCHIVE_FILENAME" "$ARCHIVE_URL"
 
 echo  -e "\e[94mExtracting to $INSTALL_DIR...\e[39m"
 mkdir -p "$INSTALL_DIR"
+rm "$INSTALL_DIR/jetbrains-toolbox" || true
 tar -xzf "$TMP_DIR/$ARCHIVE_FILENAME" -C "$INSTALL_DIR" --strip-components=1
 rm "$TMP_DIR/$ARCHIVE_FILENAME"
 chmod +x "$INSTALL_DIR/jetbrains-toolbox"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 TMP_DIR="/tmp"
 INSTALL_DIR="$HOME/.local/share/JetBrains/Toolbox/bin"
@@ -13,22 +14,22 @@ ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?cod
 ARCHIVE_FILENAME=$(basename "$ARCHIVE_URL")
 
 echo -e "\e[94mDownloading $ARCHIVE_FILENAME...\e[39m"
-rm "$TMP_DIR/$ARCHIVE_FILENAME" || true
+rm "$TMP_DIR/$ARCHIVE_FILENAME" 2>/dev/null || true
 wget -q --show-progress -cO "$TMP_DIR/$ARCHIVE_FILENAME" "$ARCHIVE_URL"
 
-echo  -e "\e[94mExtracting to $INSTALL_DIR...\e[39m"
+echo -e "\e[94mExtracting to $INSTALL_DIR...\e[39m"
 mkdir -p "$INSTALL_DIR"
-rm "$INSTALL_DIR/jetbrains-toolbox" || true
+rm "$INSTALL_DIR/jetbrains-toolbox" 2>/dev/null || true
 tar -xzf "$TMP_DIR/$ARCHIVE_FILENAME" -C "$INSTALL_DIR" --strip-components=1
 rm "$TMP_DIR/$ARCHIVE_FILENAME"
 chmod +x "$INSTALL_DIR/jetbrains-toolbox"
 
 echo -e "\e[94mSymlinking to $SYMLINK_DIR/jetbrains-toolbox...\e[39m"
 mkdir -p $SYMLINK_DIR
-rm "$SYMLINK_DIR/jetbrains-toolbox" || true
+rm "$SYMLINK_DIR/jetbrains-toolbox" 2>/dev/null || true
 ln -s "$INSTALL_DIR/jetbrains-toolbox" "$SYMLINK_DIR/jetbrains-toolbox"
 
-echo  -e "\e[94mRunning for the first time to set-up...\e[39m"
-("$INSTALL_DIR/jetbrains-toolbox" &)
+echo -e "\e[94mRunning for the first time to set-up...\e[39m"
+( "$INSTALL_DIR/jetbrains-toolbox" & )
 
-echo  -e "\n\e[32mDone! JetBrains Toolbox should now be running, in your application list, and you can run it in terminal as jetbrains-toolbox (ensure that $SYMLINK_DIR is on your PATH)\e[39m\n"
+echo -e "\n\e[32mDone! JetBrains Toolbox should now be running, in your application list, and you can run it in terminal as jetbrains-toolbox (ensure that $SYMLINK_DIR is on your PATH)\e[39m\n"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -1,39 +1,32 @@
 #!/bin/bash
 
-[ $(id -u) != "0" ] && exec sudo "$0" "$@"
-echo -e " \e[94mInstalling Jetbrains Toolbox\e[39m"
-echo ""
+set -e
 
-function getLatestUrl() {
-USER_AGENT=('User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36')
+TMP_DIR="/tmp"
+INSTALL_DIR="$HOME/.local/share/JetBrains/Toolbox/bin"
+SYMLINK_DIR="$HOME/.local/bin"
 
-URL=$(curl 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' -H 'Origin: https://www.jetbrains.com' -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-US,en;q=0.8' -H "${USER_AGENT[@]}" -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Referer: https://www.jetbrains.com/toolbox/download/' -H 'Connection: keep-alive' -H 'DNT: 1' --compressed | grep -Po '"linux":.*?[^\\]",' | awk -F ':' '{print $3,":"$4}'| sed 's/[", ]//g')
-echo $URL
-}
-getLatestUrl
+echo "### INSTALL JETBRAINS TOOLBOX ###"
 
-FILE=$(basename ${URL})
-DEST=$PWD/$FILE
+echo -e "\e[94mFetching the URL of the latest version...\e[39m"
+ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -Po '"linux":.*?[^\\]",' | awk -F ':' '{print $3,":"$4}'| sed 's/[", ]//g')
+ARCHIVE_FILENAME=$(basename "$ARCHIVE_URL")
 
-echo ""
-echo -e "\e[94mDownloading Toolbox files \e[39m"
-echo ""
-wget -cO  ${DEST} ${URL} --read-timeout=5 --tries=0
-echo ""
-echo -e "\e[32mDownload complete!\e[39m"
-echo ""
-DIR="/opt/jetbrains-toolbox"
-echo ""
-echo  -e "\e[94mInstalling to $DIR\e[39m"
-echo ""
-if mkdir ${DIR}; then
-    tar -xzf ${DEST} -C ${DIR} --strip-components=1
-fi
+echo -e "\e[94mDownloading $ARCHIVE_FILENAME...\e[39m"
+wget -q --show-progress -cO "$TMP_DIR/$ARCHIVE_FILENAME" "$ARCHIVE_URL"
 
-chmod -R +rwx ${DIR}
+echo  -e "\e[94mExtracting to $INSTALL_DIR...\e[39m"
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$TMP_DIR/$ARCHIVE_FILENAME" -C "$INSTALL_DIR" --strip-components=1
+rm "$TMP_DIR/$ARCHIVE_FILENAME"
+chmod +x "$INSTALL_DIR/jetbrains-toolbox"
 
-ln -s ${DIR}/jetbrains-toolbox /usr/local/bin/jetbrains-toolbox
-chmod -R +rwx /usr/local/bin/jetbrains-toolbox
-echo ""
-rm ${DEST}
-echo  -e "\e[32mDone.\e[39m"
+echo "\e[94mSymlinking to $SYMLINK_DIR/jetbrains-toolbox...\e[39m"
+mkdir -p $SYMLINK_DIR
+rm "$SYMLINK_DIR/jetbrains-toolbox"
+ln -s "$INSTALL_DIR/jetbrains-toolbox" "$SYMLINK_DIR/jetbrains-toolbox"
+
+echo  -e "\e[94mRunning for the first time to set-up...\e[39m"
+("$INSTALL_DIR/jetbrains-toolbox" &)
+
+echo  -e "\n\e[32mDone! JetBrains Toolbox should now be running, in your application list, and you can run it in terminal as jetbrains-toolbox (ensure that $SYMLINK_DIR is on your PATH)\e[39m\n"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -29,7 +29,10 @@ mkdir -p $SYMLINK_DIR
 rm "$SYMLINK_DIR/jetbrains-toolbox" 2>/dev/null || true
 ln -s "$INSTALL_DIR/jetbrains-toolbox" "$SYMLINK_DIR/jetbrains-toolbox"
 
-echo -e "\e[94mRunning for the first time to set-up...\e[39m"
-( "$INSTALL_DIR/jetbrains-toolbox" & )
-
-echo -e "\n\e[32mDone! JetBrains Toolbox should now be running, in your application list, and you can run it in terminal as jetbrains-toolbox (ensure that $SYMLINK_DIR is on your PATH)\e[39m\n"
+if [ -z "$CI" ]; then
+	echo -e "\e[94mRunning for the first time to set-up...\e[39m"
+	( "$INSTALL_DIR/jetbrains-toolbox" & )
+	echo -e "\n\e[32mDone! JetBrains Toolbox should now be running, in your application list, and you can run it in terminal as jetbrains-toolbox (ensure that $SYMLINK_DIR is on your PATH)\e[39m\n"
+else
+	echo -e "\n\e[32mDone! Running in a CI -- skipped launching the AppImage.\e[39m\n"
+fi

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -21,7 +21,7 @@ tar -xzf "$TMP_DIR/$ARCHIVE_FILENAME" -C "$INSTALL_DIR" --strip-components=1
 rm "$TMP_DIR/$ARCHIVE_FILENAME"
 chmod +x "$INSTALL_DIR/jetbrains-toolbox"
 
-echo "\e[94mSymlinking to $SYMLINK_DIR/jetbrains-toolbox...\e[39m"
+echo -e "\e[94mSymlinking to $SYMLINK_DIR/jetbrains-toolbox...\e[39m"
 mkdir -p $SYMLINK_DIR
 rm "$SYMLINK_DIR/jetbrains-toolbox"
 ln -s "$INSTALL_DIR/jetbrains-toolbox" "$SYMLINK_DIR/jetbrains-toolbox"


### PR DESCRIPTION
I propose some changes for the install script.

- **No sudo needed** -- JetBrains toolbox is installed to `~/.local/share/JetBrains/Toolbox` where it wants to reside anyway
- Removed some useless elements (some curl params, needless function, etc.)
- The binary is now not extracted to `/opt` (fixes #14), but to the actual location where JetBrains Toolbox installs itself after first run
- The symlink is set to point correctly to the installed toolbox binary (fixes #16) and is in a user-specific folder as well
- Make the script output nicer, more structured