### PR TITLE
Add ARM64 architecture support to installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@ This is an installer for the [JetBrains Toolbox App](https://www.jetbrains.com/t
 
 This installer automates the following steps:
 
-1. Download the latest AppImage release from the Toolbox App web page.
-2. Extract the `jetbrains-toolbox` binary to `~/.local/share/JetBrains/Toolbox/`
-3. Creates a symbolic link in the `~/.local/bin` directory
+1. Detect system architecture (x86_64 or ARM64)
+2. Download the latest AppImage release for the detected architecture from the Toolbox App web page
+3. Extract the `jetbrains-toolbox` binary to `~/.local/share/JetBrains/Toolbox/`
+4. Creates a symbolic link in the `~/.local/bin` directory
 
 (Adding the shim directory to `PATH`, creating a `.desktop` entry and setting-up autostart is done automatically by Toolbox itself.)
+
+**Supported architectures:**
+- x86_64 (Intel/AMD 64-bit)
+- ARM64/aarch64 (ARM 64-bit)
 
 ## Usage
 

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -9,8 +9,25 @@ SYMLINK_DIR="$HOME/.local/bin"
 
 echo "### INSTALL JETBRAINS TOOLBOX ###"
 
+# Detect system architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        DOWNLOAD_ARCH="linux"
+        ;;
+    aarch64|arm64)
+        DOWNLOAD_ARCH="linuxARM64"
+        ;;
+    *)
+        echo -e "\e[91mUnsupported architecture: $ARCH\e[39m"
+        echo "This script supports x86_64 and ARM64 (aarch64) architectures only."
+        exit 1
+        ;;
+esac
+
+echo -e "\e[94mDetected architecture: $ARCH (using $DOWNLOAD_ARCH)\e[39m"
 echo -e "\e[94mFetching the URL of the latest version...\e[39m"
-ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -Po '"linux":.*?[^\\]",' | awk -F ':' '{print $3,":"$4}'| sed 's/[", ]//g')
+ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -A 5 "\"$DOWNLOAD_ARCH\"" | grep -Po '"link":\s*"\K[^"]*')
 ARCHIVE_FILENAME=$(basename "$ARCHIVE_URL")
 
 echo -e "\e[94mDownloading $ARCHIVE_FILENAME...\e[39m"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -27,7 +27,7 @@ esac
 
 echo -e "\e[94mDetected architecture: $ARCH (using $DOWNLOAD_ARCH)\e[39m"
 echo -e "\e[94mFetching the URL of the latest version...\e[39m"
-ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -A 3 "\"$DOWNLOAD_ARCH\"" | grep '"link"' | head -1 | sed 's/.*"link": "\([^"]*\)".*/\1/')
+ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | sed -n 's/.*"'"$DOWNLOAD_ARCH"'":{"link":"\([^"]*\)".*/\1/p')
 if [ -z "$ARCHIVE_URL" ]; then
     echo -e "\e[91mFailed to fetch download URL for architecture: $DOWNLOAD_ARCH\e[39m"
     echo "This might indicate that JetBrains Toolbox is not available for your architecture, or there was a network issue."

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -27,11 +27,7 @@ esac
 
 echo -e "\e[94mDetected architecture: $ARCH (using $DOWNLOAD_ARCH)\e[39m"
 echo -e "\e[94mFetching the URL of the latest version...\e[39m"
-if ! command -v jq >/dev/null 2>&1; then
-    echo -e "\e[91mError: 'jq' is required but not installed. Please install 'jq' and rerun this script.\e[39m"
-    exit 1
-fi
-ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | jq -r '.TBA[0].downloads["'"$DOWNLOAD_ARCH"'"].link')
+ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -A 3 "\"$DOWNLOAD_ARCH\"" | grep '"link"' | head -1 | sed 's/.*"link": "\([^"]*\)".*/\1/')
 if [ -z "$ARCHIVE_URL" ]; then
     echo -e "\e[91mFailed to fetch download URL for architecture: $DOWNLOAD_ARCH\e[39m"
     echo "This might indicate that JetBrains Toolbox is not available for your architecture, or there was a network issue."
@@ -52,7 +48,7 @@ rm "$TMP_DIR/$ARCHIVE_FILENAME"
 chmod +x "$INSTALL_DIR/bin/jetbrains-toolbox"
 
 echo -e "\e[94mSymlinking to $SYMLINK_DIR/jetbrains-toolbox...\e[39m"
-mkdir -p $SYMLINK_DIR
+mkdir -p "$SYMLINK_DIR"
 rm "$SYMLINK_DIR/jetbrains-toolbox" 2>/dev/null || true
 ln -s "$INSTALL_DIR/bin/jetbrains-toolbox" "$SYMLINK_DIR/jetbrains-toolbox"
 

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -34,6 +34,13 @@ if [ -z "$ARCHIVE_URL" ]; then
     exit 1
 fi
 
+# Validate that we got a proper Linux tar.gz URL and not a Mac dmg or Windows exe
+if [[ ! "$ARCHIVE_URL" =~ \.tar\.gz$ ]]; then
+    echo -e "\e[91mError: Downloaded URL does not point to a .tar.gz file: $ARCHIVE_URL\e[39m"
+    echo "Expected a Linux archive but got a different format. Please report this issue."
+    exit 1
+fi
+
 ARCHIVE_FILENAME=$(basename "$ARCHIVE_URL")
 
 echo -e "\e[94mDownloading $ARCHIVE_FILENAME...\e[39m"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -28,6 +28,13 @@ esac
 echo -e "\e[94mDetected architecture: $ARCH (using $DOWNLOAD_ARCH)\e[39m"
 echo -e "\e[94mFetching the URL of the latest version...\e[39m"
 ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -A 5 "\"$DOWNLOAD_ARCH\"" | grep -Po '"link":\s*"\K[^"]*')
+
+if [ -z "$ARCHIVE_URL" ]; then
+    echo -e "\e[91mFailed to fetch download URL for architecture: $DOWNLOAD_ARCH\e[39m"
+    echo "This might indicate that JetBrains Toolbox is not available for your architecture, or there was a network issue."
+    exit 1
+fi
+
 ARCHIVE_FILENAME=$(basename "$ARCHIVE_URL")
 
 echo -e "\e[94mDownloading $ARCHIVE_FILENAME...\e[39m"

--- a/jetbrains-toolbox.sh
+++ b/jetbrains-toolbox.sh
@@ -27,8 +27,11 @@ esac
 
 echo -e "\e[94mDetected architecture: $ARCH (using $DOWNLOAD_ARCH)\e[39m"
 echo -e "\e[94mFetching the URL of the latest version...\e[39m"
-ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -A 5 "\"$DOWNLOAD_ARCH\"" | grep -Po '"link":\s*"\K[^"]*')
-
+if ! command -v jq >/dev/null 2>&1; then
+    echo -e "\e[91mError: 'jq' is required but not installed. Please install 'jq' and rerun this script.\e[39m"
+    exit 1
+fi
+ARCHIVE_URL=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | jq -r '.TBA[0].downloads["'"$DOWNLOAD_ARCH"'"].link')
 if [ -z "$ARCHIVE_URL" ]; then
     echo -e "\e[91mFailed to fetch download URL for architecture: $DOWNLOAD_ARCH\e[39m"
     echo "This might indicate that JetBrains Toolbox is not available for your architecture, or there was a network issue."


### PR DESCRIPTION
This pull request updates the JetBrains Toolbox installer to support both x86_64 and ARM64 architectures. The main changes include detecting the user's system architecture, downloading the appropriate AppImage release, and improving error handling for unsupported systems.

**Architecture support and detection:**

* Added automatic detection of system architecture (`x86_64` or `ARM64/aarch64`) in `jetbrains-toolbox.sh`, and updated the download logic to fetch the correct AppImage release for the detected architecture.
* Improved error handling in the installer script to display a clear message and exit if an unsupported architecture is detected or if the download URL cannot be fetched for the selected architecture.

**Documentation updates:**

* Updated the installation steps in `README.md` to reflect architecture detection and support for ARM64, and added a new section listing supported architectures.